### PR TITLE
Fix publishing docs with CI/CD 

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -43,8 +43,9 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: docs-html
+          path: build/html
       - name: Deploy docs to GitHub pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/html
+          publish_dir: build/html

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -36,6 +36,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
+    needs: build
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Download HTML docs artifact


### PR DESCRIPTION
Within this PR we will fix out CI/CD configuration that is
currently failing. We have two GitHub Actions workflows - first for
building the docs and artifacts and the second for publishing docs to
GitHub pages. Since the second one uses the artifacts from the first,
the second has to wait for the first to complete. We wil also update 
artifact paths for downloads in CI jobs so that the CI will suceed.

